### PR TITLE
Fix policy model method

### DIFF
--- a/lib/casbin-ruby/model/policy.rb
+++ b/lib/casbin-ruby/model/policy.rb
@@ -140,7 +140,7 @@ module Casbin
 
         model[sec][ptype].policy.each do |rule|
           value = rule[field_index]
-          values << value if values.include?(value)
+          values << value unless values.include?(value)
         end
 
         values


### PR DESCRIPTION
Because of this, some `ManagementEnforcer` methods (`get_all_roles`, `get_all_subjects`, etc) do not work correctly.